### PR TITLE
PP-3854 Force nginx to do a dns lookup every request

### DIFF
--- a/src/files/tcp.stream
+++ b/src/files/tcp.stream
@@ -1,10 +1,9 @@
 stream {
-    upstream web_server {
-        server SERVER_DNS:443;
-    }
-
     server {
+        resolver 172.18.0.2; // Amazon VPC DNS
         listen 443;
-        proxy_pass web_server;
+
+        set $upstream SERVER_DNS:443;
+        proxy_pass $upstream;
     }
 }


### PR DESCRIPTION
We do not want nginx to cache the ip of the upstream server

with @tlwr @belindac