### PR TITLE
PP-3854: Use correct comment character for nginx configs

### DIFF
--- a/src/files/tcp.stream
+++ b/src/files/tcp.stream
@@ -1,6 +1,6 @@
 stream {
     server {
-        resolver 172.18.0.2; // Amazon VPC DNS
+        resolver 172.18.0.2; # Amazon VPC DNS
         listen 443;
 
         set $upstream SERVER_DNS:443;


### PR DESCRIPTION
nginx uses # as a comment marker, not //