### PR TITLE
PP-3854: Revert all changes

### DIFF
--- a/src/files/tcp.stream
+++ b/src/files/tcp.stream
@@ -1,9 +1,10 @@
 stream {
-    server {
-        resolver 172.18.0.2; # Amazon VPC DNS
-        listen 443;
+    upstream web_server {
+        server SERVER_DNS:443;
+    }
 
-        set $upstream SERVER_DNS:443;
-        proxy_pass $upstream;
+    server {
+        listen 443;
+        proxy_pass web_server;
     }
 }


### PR DESCRIPTION
`set` is part of the http rewrite module and so isn't available to TCP proxies.

This approach to re-resolving DNS for upstream servers is not going to work.